### PR TITLE
Get active ionContent elements and refresher autocancelling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Now add the `ion-refresh-native` attribute in the `ion-refresher` component.
 ```html
 <ion-content>
 
-  <ion-refresher ion-refresh-native (ionRefresh)="doRefresh($event)">
+  <ion-refresher ion-refresh-native (ionRefresh)="doRefresh($event)" #ionRefresher>
     <ion-refresher-content pullingIcon="ios-refresh-outline" refreshingSpinner="crescent"></ion-refresher-content>
   </ion-refresher>
 

--- a/README.md
+++ b/README.md
@@ -1,71 +1,144 @@
+
 [![npm](https://img.shields.io/npm/l/ion-refresh-native.svg)](https://www.npmjs.com/package/ion-refresh-native/)
+
 [![npm](https://img.shields.io/npm/v/ion-refresh-native.svg)](https://www.npmjs.com/package/ion-refresh-native/)
+
 [![npm](https://img.shields.io/npm/dt/ion-refresh-native.svg)](https://www.npmjs.com/package/ion-refresh-native/)
+
 [![npm](https://img.shields.io/npm/dm/ion-refresh-native.svg)](https://www.npmjs.com/package/ion-refresh-native/)
+
+  
 
 # Ion Refresh Native Directive
 
+  
+
 > This directive `ion-refresh-native` extends the functionality of the `ion-refresher` or the **Pull-To-Refresh** component of the [Ionic Framework][1]. This has been tested with Ionic v3.
 
+  
+
 ### Installation ###
+
 You can install the module from [NPM][2] using the following command.
+
+  
 
 `npm i ion-refresh-native --save` or `npm install ion-refresh-native --save`
 
+  
+
 ### Usage ###
+
 + Import the Directive to your `app.module.ts`.
+
 ```typescript
-import { NgModule } from '@angular/core';
+
+import { NgModule } from  '@angular/core';
+
 ...
-import { IonRefreshNativeModule } from 'ion-refresh-native';
+
+import { IonRefreshNativeModule } from  'ion-refresh-native';
+
+  
 
 @NgModule({
-  declarations: [
-     ...
-  ],
-  imports: [
-     ...
-     IonRefreshNativeModule,
-     ...
-  ],
-  bootstrap: [IonicApp],
-  entryComponents: [],
-  providers: []
+
+declarations: [
+
+...
+
+],
+
+imports: [
+
+...
+
+IonRefreshNativeModule,
+
+...
+
+],
+
+bootstrap: [IonicApp],
+
+entryComponents: [],
+
+providers: []
+
 })
-export class AppModule {}
+
+export  class  AppModule {}
+
 ```
+
 + In your `app.scss` file, add the following:
+
 ```typescript
-@import '../../node_modules/ion-refresh-native/dist/scss/ion-refresh-native';
+
+@import  '../../node_modules/ion-refresh-native/dist/scss/ion-refresh-native';
+
 ```
+
+  
 
 ### Implementation ###
+
 Now add the `ion-refresh-native` attribute in the `ion-refresher` component.
+
 ```html
+
 <ion-content>
 
-  <ion-refresher ion-refresh-native (ionRefresh)="doRefresh($event)" #ionRefresher>
-    <ion-refresher-content pullingIcon="ios-refresh-outline" refreshingSpinner="crescent"></ion-refresher-content>
-  </ion-refresher>
+  
+
+<ion-refresher  ion-refresh-native  (ionRefresh)="doRefresh($event)">
+
+<ion-refresher-content  pullingIcon="ios-refresh-outline"  refreshingSpinner="crescent"></ion-refresher-content>
+
+</ion-refresher>
+
+  
 
 </ion-content>
+
 ```
+(Optional) In order to take advantage of the pull timeout functionality, you must declare the variable in your .ts.
+```typescript
+@ViewChild(Refresher) ionRefresher: Refresher;
+```
+  
 
 ### Inputs ###
 
+  
+
 `ion-refresh-position` (optional) Allows you to manually set the position of the icon when the refreshing state kicks off. **Default** is 55.
 
+  `refresh-timeout` (optional) Allows you to manually set the timeout (in ms) before the refresher is automatically cancelled if position is not changed. **Default** is 3000.
+  
 
 ```html
-<ion-refresher ion-refresh-position="55" ion-refresh-native (ionRefresh)="doRefresh($event)"></ion-refresher>
+
+<ion-refresher  ion-refresh-position="55" refresh-timeout="3000"  ion-refresh-native  (ionRefresh)="doRefresh($event)"></ion-refresher>
+
 ```
 
+  
+
 ### Demo ###
+
 See it live in action in this [demo][3]
 
+  
+
 ### Notes ##
+
 This is still in early stage. If any of you wants to help improve this module, please do send PR's.
 
+  
+
 [1]: https://ionicframework.com/
+
 [2]: https://www.npmjs.com/package/ion-refresh-native
+
 [3]: https://omelsoft.github.io/ion-refresh-native/docs/ion-refresh/www/index.html

--- a/README.md
+++ b/README.md
@@ -1,144 +1,74 @@
-
 [![npm](https://img.shields.io/npm/l/ion-refresh-native.svg)](https://www.npmjs.com/package/ion-refresh-native/)
-
 [![npm](https://img.shields.io/npm/v/ion-refresh-native.svg)](https://www.npmjs.com/package/ion-refresh-native/)
-
 [![npm](https://img.shields.io/npm/dt/ion-refresh-native.svg)](https://www.npmjs.com/package/ion-refresh-native/)
-
 [![npm](https://img.shields.io/npm/dm/ion-refresh-native.svg)](https://www.npmjs.com/package/ion-refresh-native/)
-
-  
 
 # Ion Refresh Native Directive
 
-  
-
 > This directive `ion-refresh-native` extends the functionality of the `ion-refresher` or the **Pull-To-Refresh** component of the [Ionic Framework][1]. This has been tested with Ionic v3.
 
-  
-
 ### Installation ###
-
 You can install the module from [NPM][2] using the following command.
-
-  
 
 `npm i ion-refresh-native --save` or `npm install ion-refresh-native --save`
 
-  
-
 ### Usage ###
-
 + Import the Directive to your `app.module.ts`.
-
 ```typescript
-
-import { NgModule } from  '@angular/core';
-
+import { NgModule } from '@angular/core';
 ...
-
-import { IonRefreshNativeModule } from  'ion-refresh-native';
-
-  
+import { IonRefreshNativeModule } from 'ion-refresh-native';
 
 @NgModule({
-
-declarations: [
-
-...
-
-],
-
-imports: [
-
-...
-
-IonRefreshNativeModule,
-
-...
-
-],
-
-bootstrap: [IonicApp],
-
-entryComponents: [],
-
-providers: []
-
+  declarations: [
+     ...
+  ],
+  imports: [
+     ...
+     IonRefreshNativeModule,
+     ...
+  ],
+  bootstrap: [IonicApp],
+  entryComponents: [],
+  providers: []
 })
-
-export  class  AppModule {}
-
+export class AppModule {}
 ```
-
 + In your `app.scss` file, add the following:
-
 ```typescript
-
-@import  '../../node_modules/ion-refresh-native/dist/scss/ion-refresh-native';
-
+@import '../../node_modules/ion-refresh-native/dist/scss/ion-refresh-native';
 ```
-
-  
 
 ### Implementation ###
-
 Now add the `ion-refresh-native` attribute in the `ion-refresher` component.
-
 ```html
-
 <ion-content>
 
-  
-
-<ion-refresher  ion-refresh-native  (ionRefresh)="doRefresh($event)">
-
-<ion-refresher-content  pullingIcon="ios-refresh-outline"  refreshingSpinner="crescent"></ion-refresher-content>
-
-</ion-refresher>
-
-  
+  <ion-refresher ion-refresh-native (ionRefresh)="doRefresh($event)">
+    <ion-refresher-content pullingIcon="ios-refresh-outline" refreshingSpinner="crescent"></ion-refresher-content>
+  </ion-refresher>
 
 </ion-content>
-
 ```
 (Optional) In order to take advantage of the pull timeout functionality, you must declare the variable in your .ts.
 ```typescript
 @ViewChild(Refresher) ionRefresher: Refresher;
 ```
-  
-
 ### Inputs ###
 
-  
-
 `ion-refresh-position` (optional) Allows you to manually set the position of the icon when the refreshing state kicks off. **Default** is 55.
-
-  `refresh-timeout` (optional) Allows you to manually set the timeout (in ms) before the refresher is automatically cancelled if position is not changed. **Default** is 3000.
-  
+`refresh-timeout` (optional) Allows you to manually set the timeout (in ms) before the refresher is automatically cancelled if position is not changed. **Default** is 3000.
 
 ```html
-
-<ion-refresher  ion-refresh-position="55" refresh-timeout="3000"  ion-refresh-native  (ionRefresh)="doRefresh($event)"></ion-refresher>
-
+<ion-refresher ion-refresh-position="55" refresh-timeout="3000" ion-refresh-native (ionRefresh)="doRefresh($event)"></ion-refresher>
 ```
 
-  
-
 ### Demo ###
-
 See it live in action in this [demo][3]
 
-  
-
 ### Notes ##
-
 This is still in early stage. If any of you wants to help improve this module, please do send PR's.
 
-  
-
 [1]: https://ionicframework.com/
-
 [2]: https://www.npmjs.com/package/ion-refresh-native
-
 [3]: https://omelsoft.github.io/ion-refresh-native/docs/ion-refresh/www/index.html

--- a/src/directives/ion-refresh-native.ts
+++ b/src/directives/ion-refresh-native.ts
@@ -1,5 +1,6 @@
 import {Directive, ElementRef, Renderer, Input} from '@angular/core';
 import { NavController } from 'ionic-angular/navigation/nav-controller';
+import { Refresher } from 'ionic-angular/umd/components/refresher/refresher';
 
 @Directive({
    selector: '[ion-refresh-native]', // Attribute selector
@@ -19,31 +20,32 @@ export class IonRefreshNative {
       ready: 'ready',
       refreshing: 'refreshing',
    };
-
+   private pullTimeout: any;
    private ionPulling;
    private ionPullingIcon;
    private ionRefreshing;
+   private ionRefresher: Refresher;
 
    public progress;
    public rotation;
 
-   constructor(public element : ElementRef, public renderer : Renderer, public navCtrl: NavController) {}
+   constructor(public element : ElementRef, public renderer : Renderer, public navCtrl: NavController) { }
 
    handleStart(event) {
-      const contentElement = this.navCtrl.getActive().getIONContentRef().nativeElement;
-      if (!this.ionPulling || !this.ionPullingIcon || !this.ionRefreshing) {
-         this.ionPulling = contentElement.getElementsByClassName('refresher-pulling-icon')[0];
-         this.ionPullingIcon = contentElement.querySelector('.refresher-pulling-icon > ion-icon');
-         this.ionRefreshing = contentElement.getElementsByClassName('refresher-refreshing')[0];
-      }
+    const activePage = this.navCtrl.getActive();
+    const contentElement = activePage.getIONContentRef().nativeElement;
+    if (!this.ionPulling || !this.ionPullingIcon || !this.ionRefreshing) {
+        this.ionPulling = contentElement.getElementsByClassName('refresher-pulling-icon')[0];
+        this.ionPullingIcon = contentElement.querySelector('.refresher-pulling-icon > ion-icon');
+        this.ionRefreshing = contentElement.getElementsByClassName('refresher-refreshing')[0];
+        this.ionRefresher = activePage.instance.ionRefresher;
+    }
    }
 
    handlePull(event) {
-
       this.progress = event.progress * event.pullMin + event.deltaY;
       this.rotation = this.progress * 2;
       this.ionRefreshPosition = this.ionRefreshPosition ? this.ionRefreshPosition : 55;
-
       if (this.progress < event.pullMax) {
          this.setStyle(
                this.ionPulling,
@@ -68,16 +70,21 @@ export class IonRefreshNative {
             transition: ease-in-out 100ms transform;`
             );
       }
+      clearTimeout(this.pullTimeout);
+      this.pullTimeout = setTimeout(() => {
+        this.ionRefresher.cancel();
+      }, 5000);
    }
 
    handleRefresh(event) {
-      this.setStyle(
-         this.ionRefreshing,
-         'style',
-         `transform: translateY(${this.ionRefreshPosition}px) translateZ(0px)!important;
-         transition: ease-in-out 1000ms transform;`
-         );
-      this.resetPullingStyle()
+    clearTimeout(this.pullTimeout);
+    this.setStyle(
+        this.ionRefreshing,
+        'style',
+        `transform: translateY(${this.ionRefreshPosition}px) translateZ(0px)!important;
+        transition: ease-in-out 1000ms transform;`
+        );
+    this.resetPullingStyle()
    }
 
    setStyle(element : ElementRef, attr, value) {

--- a/src/directives/ion-refresh-native.ts
+++ b/src/directives/ion-refresh-native.ts
@@ -1,4 +1,5 @@
 import {Directive, ElementRef, Renderer, Input} from '@angular/core';
+import { NavController } from 'ionic-angular/navigation/nav-controller';
 
 @Directive({
    selector: '[ion-refresh-native]', // Attribute selector
@@ -26,13 +27,14 @@ export class IonRefreshNative {
    public progress;
    public rotation;
 
-   constructor(public element : ElementRef, public renderer : Renderer) {}
+   constructor(public element : ElementRef, public renderer : Renderer, public navCtrl: NavController) {}
 
    handleStart(event) {
+      const contentElement = this.navCtrl.getActive().getIONContentRef().nativeElement;
       if (!this.ionPulling || !this.ionPullingIcon || !this.ionRefreshing) {
-         this.ionPulling = this.element.nativeElement.getElementsByClassName('refresher-pulling-icon')[0];
-         this.ionPullingIcon = document.querySelector('.refresher-pulling-icon > ion-icon');
-         this.ionRefreshing = this.element.nativeElement.getElementsByClassName('refresher-refreshing')[0];
+         this.ionPulling = contentElement.getElementsByClassName('refresher-pulling-icon')[0];
+         this.ionPullingIcon = contentElement.querySelector('.refresher-pulling-icon > ion-icon');
+         this.ionRefreshing = contentElement.getElementsByClassName('refresher-refreshing')[0];
       }
    }
 

--- a/src/directives/ion-refresh-native.ts
+++ b/src/directives/ion-refresh-native.ts
@@ -12,6 +12,7 @@ import { Refresher } from 'ionic-angular/umd/components/refresher/refresher';
 })
 export class IonRefreshNative {
    @Input('ion-refresh-position') ionRefreshPosition: number;
+   @Input('refresh-timeout') refreshTimeout: number;
 
    private STATE = {
       comleting: 'completing',
@@ -45,7 +46,7 @@ export class IonRefreshNative {
    handlePull(event) {
       this.progress = event.progress * event.pullMin + event.deltaY;
       this.rotation = this.progress * 2;
-      this.ionRefreshPosition = this.ionRefreshPosition ? this.ionRefreshPosition : 55;
+      this.ionRefreshPosition = this.ionRefreshPosition || 55;
       if (this.progress < event.pullMax) {
          this.setStyle(
                this.ionPulling,
@@ -71,9 +72,11 @@ export class IonRefreshNative {
             );
       }
       clearTimeout(this.pullTimeout);
-      this.pullTimeout = setTimeout(() => {
-        this.ionRefresher.cancel();
-      }, 5000);
+      if (typeof this.ionRefresher !== 'undefined') {
+         this.pullTimeout = setTimeout(() => {
+            this.ionRefresher.cancel();
+          }, this.refreshTimeout || 3000);
+      }
    }
 
    handleRefresh(event) {


### PR DESCRIPTION
#### Bugfix
Directive can now be added to multiple pages in the stack - it would previously continue referencing the one in the root page
#### Enhancement
Added timeout to avoid ion-refresher getting stuck when loading data and refreshing simultaneously 